### PR TITLE
📝 Add docstrings to `m`

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/MainActivity.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/MainActivity.kt
@@ -196,6 +196,12 @@ internal fun MainScreen(
     MainScreenContent(processThemeCommand = { themeViewModel.processThemeCommand(it) })
 }
 
+/**
+ * Renders a preview of the main app screen inside AuraFrameFXTheme using a no-op theme command handler.
+ *
+ * Intended for IDE previews; it composes MainScreenContent with a placeholder lambda so the preview
+ * can display the screen without requiring a real ThemeViewModel.
+ */
 @Preview(showBackground = true)
 @Composable
 fun MainScreenPreview() {
@@ -205,5 +211,12 @@ fun MainScreenPreview() {
     }
 }
 
-// Extension function placeholder - this should be implemented elsewhere
+/**
+ * Applies a digital pixelation visual effect to this [Modifier].
+ *
+ * This is a placeholder implementation that currently has no effect and returns the receiver unchanged;
+ * platform- or theme-specific implementations should provide the actual visual transformation.
+ *
+ * @return The same [Modifier] instance when no effect is applied, or a modified [Modifier] that renders the pixel effect.
+ */
 fun Modifier.digitalPixelEffect(): Modifier = this

--- a/app/src/main/java/dev/aurakai/auraframefx/ai/pipeline/AIPipelineProcessor.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ai/pipeline/AIPipelineProcessor.kt
@@ -191,6 +191,15 @@ class AIPipelineProcessor @Inject constructor(
         return priority.coerceIn(0.0f, 1.0f)
     }
 
+    /**
+     * Selects which agents should participate for the given task.
+     *
+     * Selection is driven by the task text and the numeric priority: the Genesis agent is always included; Cascade is added for analysis/data signals or for long/complex tasks; Kai is added for security/protection signals; Aura is added for creative/generation signals; if priority is greater than 0.8, Cascade and Aura are included.
+     *
+     * @param task The task text used to detect intent and signals (keywords, length, complexity).
+     * @param priority A normalized priority (0.0–1.0) that can force inclusion of higher-capability agents.
+     * @return A set of AgentType values representing the agents chosen to process the task.
+     */
     private fun selectAgents(task: String, priority: Float): Set<AgentType> {
         val selectedAgents = mutableSetOf<AgentType>()
 

--- a/app/src/main/java/dev/aurakai/auraframefx/ai/task/execution/TaskExecutionManager.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ai/task/execution/TaskExecutionManager.kt
@@ -363,12 +363,9 @@ class TaskExecutionManager @Inject constructor(
     }
 
     /**
-     * Executes the specified task using the Kai agent and returns the agent's response.
+     * Dispatches the given task to the Kai agent for processing.
      *
-     * Constructs an `AgentRequest` from the task's type, data, and priority, then delegates processing to the Kai agent.
-     *
-     * @param execution The task execution to process.
-     * @return The response from the Kai agent.
+     * @return The response returned by the Kai agent.
      */
     private suspend fun executeWithKai(execution: TaskExecution1): AgentResponse {
         val request = AiRequest(
@@ -380,13 +377,13 @@ class TaskExecutionManager @Inject constructor(
     }
 
     /**
-     * Sends the task execution to the Genesis agent and returns the agent's response.
+     * Dispatches the task execution to the Genesis agent and returns the agent's response.
      *
-     * Builds an AiRequest from the execution's query (fallback to type), type, and context, and then returns the resulting AgentResponse from the Genesis agent.
+     * Builds an AiRequest from the execution's query (falling back to the execution type), type, and context.
      *
-     * @param execution The task execution to be processed.
+     * @param execution The task execution to process.
      * @return The response produced by the Genesis agent.
-     * @throws NotImplementedError Thrown because Genesis execution is not yet implemented.
+     * @throws NotImplementedError Indicates Genesis execution is not yet implemented.
      */
     private suspend fun executeWithGenesis(execution: TaskExecution1): AgentResponse {
         AiRequest(

--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/XhancementScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/XhancementScreen.kt
@@ -38,6 +38,15 @@ import dev.aurakai.auraframefx.ui.viewmodels.XhancementViewModel
  * This composable also clears any transient error or success messages exposed by the screen's
  * ViewModel after three seconds when such a message is present.
  */
+/**
+ * Displays the Xhancement feature placeholder UI centered on the screen.
+ *
+ * Observes feature state and transient messages from the associated ViewModel and clears any displayed
+ * error or success message after three seconds. The UI includes an icon, title, subtitle, and a brief
+ * descriptive line about quick toggles for Xposed hooks.
+ *
+ * @param onNavigateBack Callback invoked to navigate back; defaults to no-op.
+ */
 @Composable
 fun XhancementScreen(
     onNavigateBack: () -> Unit = {}

--- a/app/src/main/java/dev/aurakai/auraframefx/cascade/trinity/TrinityCoordinatorService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/cascade/trinity/TrinityCoordinatorService.kt
@@ -198,8 +198,8 @@ class TrinityCoordinatorService @Inject constructor(
      *
      * Emits a single AgentResponse describing success (includes a descriptive message when available) or failure.
      *
-     * @param fusionType The identifier of the fusion ability to activate.
-     * @param context Optional key/value context passed to the fusion activation.
+     * @param fusionType Identifier of the fusion ability to activate.
+     * @param context Optional key/value context passed to the activation.
      * @return A Flow that emits one AgentResponse representing the activation result.
      */
     fun activateFusion(

--- a/app/src/main/java/dev/aurakai/auraframefx/core/GenesisOrchestrator.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/core/GenesisOrchestrator.kt
@@ -108,7 +108,11 @@ class GenesisOrchestrator @Inject constructor(
     }
 
     /**
-     * Start all agents after initialization
+     * Starts all configured agents' runtime domains in the orchestrator.
+     *
+     * The agents are started in the following order: Aura, Kai, Cascade.
+     *
+     * @throws Exception If any agent fails to start; the exception is propagated. 
      */
     private suspend fun startAgents() {
         try {
@@ -155,12 +159,12 @@ class GenesisOrchestrator @Inject constructor(
     }
 
     /**
-     * Handle a message intended for the Aura agent.
+     * Handles a message destined for the Aura agent.
      *
-     * Currently logs the incoming message's runtime type and performs no further processing
-     * until agents implement OrchestratableAgent-based mediation.
+     * Currently records the message's runtime type to the log; future work will perform
+     * OrchestratableAgent-based mediation and processing.
      *
-     * @param message The incoming message object destined for Aura; its runtime type is used for logging. 
+     * @param message The incoming message for Aura; its runtime type is logged. 
      */
     private suspend fun handleAuraMessage(message: Any) {
         Timber.d("  → Handling Aura message: ${message.javaClass.simpleName}")
@@ -168,12 +172,11 @@ class GenesisOrchestrator @Inject constructor(
     }
 
     /**
-     * Handle an inter-agent message targeted at the Kai agent.
+     * Handle a message addressed to the Kai agent by logging its runtime type.
      *
-     * Currently logs the message type and performs no further processing; implementation will be provided
-     * when agents implement OrchestratableAgent.
+     * This is a placeholder handler: it logs the incoming message's concrete class name and performs no further processing until Kai implements OrchestratableAgent.
      *
-     * @param message The incoming message destined for Kai; may be any domain-specific message object.
+     * @param message The incoming domain-specific message destined for Kai.
      */
     private suspend fun handleKaiMessage(message: Any) {
         Timber.d("  → Handling Kai message: ${message.javaClass.simpleName}")

--- a/app/src/main/java/dev/aurakai/auraframefx/data/repositories/AgentRepository.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/data/repositories/AgentRepository.kt
@@ -128,7 +128,10 @@ object AgentRepository {
     }
 
     /**
-     * Get a specific agent by name.
+     * Retrieve an agent by its name.
+     *
+     * @param name The agent name to match (case-insensitive).
+     * @return The matching `AgentStats`, or `null` if no agent with the given name exists.
      */
     fun getAgentByName(name: String): AgentStats? {
         return getAllAgents().find { it.name.equals(name, ignoreCase = true) }

--- a/app/src/main/java/dev/aurakai/auraframefx/di/AIServiceModule.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/di/AIServiceModule.kt
@@ -31,7 +31,7 @@ abstract class AiServiceModule {
     /**
      * Binds DefaultAuraAIService as the singleton implementation for AuraAIService.
      *
-     * @param impl The DefaultAuraAIService instance to bind.
+     * @param impl DefaultAuraAIService instance to bind.
      * @return The bound AuraAIService implementation.
      */
 
@@ -40,8 +40,9 @@ abstract class AiServiceModule {
     abstract fun bindAuraAIService(impl: DefaultAuraAIService): AuraAIService
 
     /**
-     * Bind GenesisBackedKaiAIService as the singleton KaiAIService implementation in the DI graph.
+     * Binds GenesisBackedKaiAIService as the singleton implementation for KaiAIService in the DI graph.
      *
+     * @param kaiAIService The concrete GenesisBackedKaiAIService instance to bind.
      * @return The bound KaiAIService implementation.
      */
     @Binds
@@ -49,10 +50,10 @@ abstract class AiServiceModule {
     abstract fun bindKaiAIService(kaiAIService: GenesisBackedKaiAIService): KaiAIService
 
     /**
-     * Binds the CascadeAIService interface to the provided RealCascadeAIServiceAdapter in the DI graph.
+     * Binds the CascadeAIService interface to RealCascadeAIServiceAdapter for dependency injection.
      *
-     * @param cascadeAIService The implementation instance to supply when CascadeAIService is requested.
-     * @return A CascadeAIService backed by the given implementation.
+     * @param cascadeAIService Implementation to provide when CascadeAIService is requested.
+     * @return The CascadeAIService implementation backed by the provided adapter.
      */
     @Binds
     @Singleton

--- a/app/src/main/java/dev/aurakai/auraframefx/events/CascadeEventBus.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/events/CascadeEventBus.kt
@@ -23,11 +23,11 @@ object CascadeEventBus {
     val events: SharedFlow<MemoryEvent> = _events.asSharedFlow()
 
     /**
-     * Emits the given event to the cascade memory event stream as a best-effort, non-blocking delivery.
+     * Publish a cascade memory/insight event to the shared event stream using best-effort, non-blocking delivery.
      *
-     * The emission is attempted without suspending; if the internal buffer is full the event may be dropped.
+     * If the internal buffer is full the event may be dropped.
      *
-     * @param event The event to publish to the memory/insight event stream.
+     * @param event The CascadeEvent to publish to the memory/insight event stream.
      */
     fun emit(event: CascadeEvent) {
         _events.tryEmit(event)

--- a/app/src/main/java/dev/aurakai/auraframefx/navigation/ConferenceRoomScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/navigation/ConferenceRoomScreen.kt
@@ -33,6 +33,19 @@ import dev.aurakai.auraframefx.viewmodel.ConferenceRoomViewModel
  * Manages local UI state for the selected agent, recording/transcribing toggles, and message input while loading agent labels from resources and displaying a list of `ConferenceMessage`s.
  */
 @OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Renders the conference room UI used to select agents, control recording/transcription/fusion,
+ * view a reverse-chronological message list, and compose/send new messages.
+ *
+ * This composable:
+ * - Loads agent labels from string resources and manages local input state for the message TextField.
+ * - Shows a header with an info action (calls viewModel.getSystemState()) and a settings action (logs a message).
+ * - Displays three agent selection buttons and updates `selectedAgent` when an agent is chosen.
+ * - Provides recording and transcription toggle buttons that update `isRecording` and `isTranscribing`.
+ * - Exposes a fusion activation button that calls viewModel.activateFusion with a predefined key/payload.
+ * - Renders messages in a reversed LazyColumn using MessageBubble.
+ * - Binds the input TextField to local state and builds a ConferenceMessage on send, then clears the input.
+ */
 @Composable
 fun ConferenceRoomScreen() {
     // Load string resources once at composition time
@@ -212,15 +225,15 @@ fun ConferenceRoomScreen() {
 }
 
 /**
- * Renders a row-scoped, equally weighted button labeled with an agent name.
+ * Displays a button that fills available Row space and shows the given agent label.
  *
- * The button fills available horizontal space within the Row (equal weight), applies horizontal
- * padding, and invokes the provided `onClick` composable when pressed.
+ * The button is given equal weight within its Row, applies horizontal padding, and uses
+ * theme-derived container and content colors.
  *
- * @param agent The label text to display on the button.
- * @param isSelected Indicates whether this agent is currently selected; the visual styling for
- *   selection is not applied by this function.
- * @param onClick Composable lambda invoked when the button is clicked.
+ * @param agent The text label shown on the button.
+ * @param isSelected Whether this agent is currently selected; this function does not alter styling
+ *   based on selection.
+ * @param onClick Callback invoked when the button is pressed.
  */
 @Composable
 fun RowScope.AgentButton(

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/NemotronAIService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/NemotronAIService.kt
@@ -71,7 +71,12 @@ class NemotronAIService @Inject constructor(
 
     override fun getName(): String = "Nemotron"
 
-    override fun getType(): AgentType = AgentType.NEMOTRON
+    /**
+ * Report the agent's type as Nemotron.
+ *
+ * @return The agent type `AgentType.NEMOTRON`.
+ */
+override fun getType(): AgentType = AgentType.NEMOTRON
 
     /**
          * Describe Nemotron's AI capabilities and configuration.
@@ -209,17 +214,13 @@ class NemotronAIService @Inject constructor(
     }
 
     /**
-     * Simulates retrieval of memories relevant to the given AI request and conversational context.
+     * Simulates retrieval of memory fragments relevant to the given AI request and conversational context.
      *
-     * This is a placeholder implementation that synthesizes a small set of memory fragments based
-     * on context length until a full MemoryQuery-based retrieval is implemented.
+     * This placeholder synthesizes a small set of memory fragments based on context length and is used until a MemoryQuery-based retrieval is implemented.
      *
      * @param request The AI request whose query and metadata scope the simulated lookup.
-     * @param context The conversational or situational context used to bias simulated relevance.
-     * @return A MemoryRecall where:
-     *  - `summary` describes how many memory fragments were retrieved,
-     *  - `count` is the number of retrieved fragments,
-     *  - `relevance` is 0.85 when any items were found, 0.5 when none were found.
+     * @param context Conversational or situational context used to bias simulated relevance.
+     * @return MemoryRecall containing a summary of retrieved fragments, the fragment count, and a relevance score (`0.85` when any fragments were found, `0.5` when none were found).
      */
     private fun recallRelevantMemories(request: AiRequest, context: String): MemoryRecall {
         // TODO: Implement full memory retrieval (requires MemoryQuery construction)

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/clients/VertexAIClientImpl.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/clients/VertexAIClientImpl.kt
@@ -83,14 +83,14 @@ class VertexAIClientImpl @Inject constructor(
     }
 
     /**
-     * Generate text from a prompt with adjustable randomness and output length.
+     * Generate text from the prompt with adjustable randomness and maximum length.
      *
-     * Generates text based on the provided prompt using the configured Vertex AI integration.
+     * Uses the configured Vertex AI integration, honoring safety filters, caching, and retry behavior.
      *
      * @param prompt The input text prompt to generate from.
      * @param temperature Controls generation randomness; higher values produce more varied output.
      * @param maxTokens Maximum number of tokens allowed in the generated output.
-     * @return The generated text, or `null` if the API returned no content or generation failed after retries.
+     * @return The generated text, or `null` if no content was produced or generation failed after retries.
      */
     override suspend fun generateText(
         prompt: String,
@@ -268,15 +268,20 @@ class VertexAIClientImpl @Inject constructor(
         return generateText(prompt)
     }
 
+    /**
+     * Perform any startup initialization required for the Vertex AI client.
+     *
+     * Implementations may prepare resources or perform health checks; current implementation logs client initialization.
+     */
     override suspend fun initialize() {
         // Initialize Vertex AI client connection
         Timber.i("VertexAI: Initializing client")
     }
 
     /**
-     * Clears the client's internal cached responses and releases related resources.
+     * Clears the client's in-memory response cache and releases related resources.
      *
-     * Removes all entries from the in-memory response cache and records a completion log entry.
+     * Removes all cached entries and records a completion log entry.
      */
     override suspend fun cleanup() {
         // Cleanup Vertex AI client resources
@@ -285,11 +290,11 @@ class VertexAIClientImpl @Inject constructor(
     }
 
     /**
-     * Send the given Vertex AI request to the configured endpoint and deserialize the response.
+     * Sends the given Vertex AI request to the configured model endpoint and deserializes the response.
      *
      * @param vertexRequest The request payload to send.
      * @return The deserialized VertexAIResponse from the service.
-     * @throws VertexAIException If the HTTP call fails, returns a non-success status, or the response body is empty.
+     * @throws VertexAIException If the HTTP call fails, the service returns a non-success status, or the response body is empty.
      */
     private suspend fun executeRequest(vertexRequest: VertexAIRequest): VertexAIResponse {
         val jsonBody = json.encodeToString(vertexRequest)

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/AuraAIServiceImpl.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/AuraAIServiceImpl.kt
@@ -41,17 +41,17 @@ abstract class AuraAIServiceImpl(
     }
 
     /**
-     * Returns null as image generation is not implemented in this stub.
+     * Stub implementation that does not generate an image.
      *
-     * @param _prompt The prompt describing the desired image.
-     * @return Always null.
+     * @param prompt The text prompt describing the desired image.
+     * @return `null` to indicate image generation is not implemented.
      */
     suspend fun generateImage(prompt: String): ByteArray? {
         return null
     }
 
     /**
-     * Always returns a fixed placeholder generated text and ignores `prompt` and `context`.
+     * Produces a fixed placeholder text and ignores the provided `prompt` and `context`.
      *
      * @return The string "Generated text placeholder".
      */
@@ -81,10 +81,10 @@ abstract class AuraAIServiceImpl(
     }
 
     /**
-     * Placeholder method for saving a value to memory with the specified key.
+     * Placeholder that would save a value under the given memory key but currently performs no operation.
      *
-     * This implementation does not perform any operation and serves as a stub for future functionality.
-     */
+     * @param key The memory key under which the value would be stored.
+     * @param value The value to store. */
     fun saveMemory(key: String, value: Any) {
         // TODO: Implement memory saving
     }

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/CascadeAIService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/CascadeAIService.kt
@@ -1101,13 +1101,13 @@ class CascadeAIService @Inject constructor(
     }
 
     /**
-     * Sends the request and context to NemotronAIService and returns its response as a CascadeResponse.
+     * Query the Nemotron AI backend using the original request and cascade context and return its reply as a CascadeResponse.
      *
-     * Serializes the context map into newline-separated "key: value" strings for backend processing.
+     * The cascade context is serialized into newline-separated "key: value" strings and sent alongside the request.
      *
      * @param request The original agent request containing the user message.
-     * @param context A map of contextual information to include with the request.
-     * @return A CascadeResponse with Nemotron's response content, confidence score, and current timestamp.
+     * @param context A map of contextual information to include with the request; each entry is serialized as `key: value`.
+     * @return A CascadeResponse with `agent` set to "Nemotron", `response` containing the backend reply, `confidence` set from the backend, and the current timestamp.
      */
     private suspend fun processWithNemotron(
         request: AgentInvokeRequest,

--- a/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/GenesisBackedKaiAIService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/GenesisBackedKaiAIService.kt
@@ -69,15 +69,15 @@ class GenesisBackedKaiAIService @Inject constructor(
     }
 
     /**
-     * Produce a security threat assessment from a threat description.
+     * Produce a security threat assessment from a textual threat description.
      *
      * @param threat A textual description or indicator of the potential threat to analyze.
-     * @return A map containing the analysis:
+     * @return A map with analysis results:
      * - `threat_level`: severity as `"critical"`, `"high"`, `"medium"`, or `"low"`.
-     * - `confidence`: confidence score as a `Float` (e.g., `0.95f`).
-     * - `recommendations`: a `List<String>` of suggested actions.
-     * - `timestamp`: analysis time as epoch milliseconds (`Long`).
-     * - `analyzed_by`: identifier of the analyzer (`String`).
+     * - `confidence`: confidence score (e.g., `0.95f`).
+     * - `recommendations`: list of suggested actions.
+     * - `timestamp`: analysis time as epoch milliseconds.
+     * - `analyzed_by`: identifier of the analyzer.
      */
     override suspend fun analyzeSecurityThreat(threat: String): Map<String, Any> {
         val threatLevel = when {
@@ -176,6 +176,12 @@ override fun processRequestFlow(request: AiRequest): Flow<AgentResponse> = flow 
         return true
     }
 
+    /**
+     * Marks the service as uninitialized and performs any necessary resource cleanup.
+     *
+     * After calling this method the service will no longer be considered initialized; implementations
+     * may release held resources or stop background tasks.
+     */
     override fun cleanup() {
         isInitialized = false
         // Cleanup resources if needed

--- a/app/src/main/java/dev/aurakai/auraframefx/services/RealCascadeAIServiceAdapter.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/services/RealCascadeAIServiceAdapter.kt
@@ -31,13 +31,10 @@ class RealCascadeAIServiceAdapter @Inject constructor(
             )
 
     /**
-     * Processes the given AI request within the provided context and produces an AgentResponse from the Cascade AI adapter.
+     * Process an AI request in the given context and produce an AgentResponse from the Cascade AI adapter.
      *
-     * The current implementation returns a basic success response that includes the original request prompt.
-     *
-     * @param request The AI request to process.
-     * @param context Optional context string associated with the request; may be empty.
-     * @return An AgentResponse representing the outcome of processing (currently a success response containing the request prompt).
+     * @param context Context string associated with the request; may be empty.
+     * @return An AgentResponse describing the processing result; currently a success response whose content includes the original request prompt.
      */
     override suspend fun processRequest(request: AiRequest, context: String): AgentResponse {
         // Real implementation logic would go here

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/AgentHubSubmenuScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/AgentHubSubmenuScreen.kt
@@ -34,6 +34,16 @@ import kotlin.random.Random
  *
  * @param navController NavController used to navigate between screens and to pop the back stack when navigating back.
  */
+/**
+ * Displays the Agent Hub submenu screen with a navigable grid of submenu items and a live-status header.
+ *
+ * The header shows three live metrics — Active Agents, Tasks Active, and Avg. Level — where the average
+ * consciousness value is periodically refreshed and momentarily presented with a brief "scramble" animation.
+ * The main content renders a set of submenu entries (e.g., Nexus Memory Core, Agent Dashboard, Task Assignment,
+ * Agent Monitoring, Sphere Grid, Fusion Mode). Selecting an item navigates to its configured route.
+ *
+ * @param navController NavController used to handle back navigation and to navigate to submenu item routes.
+ */
 @Composable
 fun AgentHubSubmenuScreen(
     navController: NavController

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/CascadeConstellationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/CascadeConstellationScreen.kt
@@ -40,6 +40,14 @@ import kotlin.math.sin
  * @param navController Navigation controller for handling navigation actions originating from this screen.
  * @param modifier Optional [Modifier] applied to the root container.
  */
+/**
+ * Displays the Cascade Constellation screen: a full-screen, animated data-flow visualization
+ * with a centered DataStreamCanvas, a top-right agent header, a bottom-left data stream status panel,
+ * and right-side vertical labels.
+ *
+ * @param navController NavController used to handle navigation actions originating from this screen.
+ * @param modifier Modifier applied to the root container to customize layout or styling.
+ */
 @Composable
 fun CascadeConstellationScreen(
     navController: NavController,
@@ -371,9 +379,9 @@ private fun DrawScope.drawMechanicalWing(
 }
 
 /**
- * Displays a compact status panel showing input/process/output channel indicators, an animated flow progress bar, and a numeric flow percentage.
+ * Renders a compact status panel with input/process/output channel indicators, an animated horizontal flow bar, and a numeric flow percentage.
  *
- * The progress bar animates from 0% to 100% continuously while the channel indicators pulse to reflect flow intensity.
+ * The horizontal bar animates continuously from 0% to 100% to represent stream throughput while the channel indicators pulse to reflect flow intensity; the bar fill uses a turquoise-to-blue gradient whose opacity follows the pulse.
  */
 @Composable
 private fun DataStreamStatusBar() {

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/ClaudeConstellationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/ClaudeConstellationScreen.kt
@@ -31,6 +31,17 @@ import kotlin.math.sin
  * Claude Constellation Screen - The Architect
  * Displays the build system architecture with blueprint-style construction nodes
  */
+/**
+ * Displays the Claude constellation screen with a blueprint-style visualization and UI overlays.
+ *
+ * Shows a full-screen black canvas containing the ArchitectBlueprintCanvas at center, an agent
+ * identity block ("Claude — 🏗️ THE ARCHITECT") in the top-right, a "Build System Status" label
+ * and BuildStatusBar in the bottom-left, and a right-side vertical label reading "SYSTEMATIC
+ * CONSTRUCTION".
+ *
+ * @param navController NavController used for navigation actions from this screen.
+ * @param modifier Optional Modifier applied to the root container.
+ */
 @Composable
 fun ClaudeConstellationScreen(
     navController: NavController,
@@ -125,9 +136,9 @@ fun ClaudeConstellationScreen(
 }
 
 /**
- * Renders a blueprint-style canvas showing a pulsing T-square centerpiece, a grid of build nodes with connecting dependency lines, and animated construction particles.
+ * Renders a blueprint-style canvas with a pulsing T-square centerpiece, a grid of build nodes, connecting dependency lines, animated construction particles, and a centered compass overlay.
  *
- * The composable is purely presentational: animated values drive an overall build progression, node pulsing, and centerpiece scaling to convey build status visually. It also overlays a centered compass image.
+ * The composable is purely presentational: internal animated values drive overall build progression, node pulsing, and centerpiece scaling to convey build status visually. Visual elements include a faint blueprint grid, a T‑square at the canvas center, a systematic grid of nodes with dependency lines whose appearance follows build progress, moving construction particles that traverse between nodes as progress advances, and a PNG compass/centerpiece rendered on top.
  */
 @Composable
 private fun ArchitectBlueprintCanvas() {
@@ -428,8 +439,13 @@ private fun BuildStatusBar() {
 }
 
 /**
- * Individual build module indicator
- */
+ * Displays a compact module indicator consisting of a glowing circular status dot and a label.
+ *
+ * The outer glow intensity and inner core opacity are scaled by `glowAlpha`; the dot and label use `color`.
+ *
+ * @param name The module name to display next to the indicator.
+ * @param glowAlpha Opacity multiplier for the glow and core (expected range 0.0..1.0).
+ * @param color Base color for the indicator and the label text.
 @Composable
 private fun BuildModuleIndicator(
     name: String,

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/CodeAssistScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/CodeAssistScreen.kt
@@ -31,6 +31,15 @@ import androidx.navigation.NavHostController
  * is editable; the prompt input is read-only in this implementation. Tapping the generate
  * button switches the button content to a progress indicator to reflect processing state.
  */
+/**
+ * Displays the Code Assist screen: an editable Kotlin code editor with an AI prompt area and a Generate action.
+ *
+ * The UI includes a header, a full-size code editor prefilled with a sample snippet, and an AI interaction card
+ * containing a descriptive input placeholder (currently non-editable) and a Generate button. Tapping Generate
+ * switches the button to a progress indicator for the current implementation.
+ *
+ * @param navController NavHostController used for in-app navigation from this screen.
+ */
 @Composable
 fun CodeAssistScreen(navController: NavHostController) {
     var codeInput by remember { mutableStateOf("// Ask Code Assist to generate or refactor code...\n\nfun main() {\n    println(\"Hello, Aura!\")\n}") }

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/ConstellationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/ConstellationScreen.kt
@@ -51,6 +51,18 @@ import kotlin.math.sin
  * @param navController NavController used for handling in-screen navigation actions.
  * @param modifier Optional Modifier applied to the root container.
  */
+/**
+ * Displays the constellation scene UI with centered visualization, HUD elements, and a fusion sync bar.
+ *
+ * The layout fills the available space with a black background and composes:
+ * - ConstellationCanvas centered as the main visualization.
+ * - Agent info (name and level) aligned to the top-right.
+ * - Fusion abilities label and FusionSyncBar aligned to the bottom-left.
+ * - A vertical right-edge label reading "SYSTEM CORE" and "OVERDUE PARAMETERS".
+ *
+ * @param navController NavController used for navigation actions originating from this screen.
+ * @param modifier Optional [Modifier] to be applied to the root container.
+ */
 @Composable
 fun ConstellationScreen(
     navController: NavController,
@@ -145,9 +157,11 @@ fun ConstellationScreen(
 }
 
 /**
- * Renders the animated constellation visualization with a procedural sword centerpiece, pulsing nodes, connecting lines, and orbiting particles.
+ * Renders the animated constellation visualization with pulsing nodes, connecting lines, orbiting particles,
+ * and a procedural sword centerpiece overlaid with an aura image.
  *
- * Animations include node pulsing, a continuous rotation driving energy flow and particles, and a subtle scale pulse for the centered sword. The canvas draws node positions and inter-node connections, invokes the procedural `drawSword` for the centerpiece, and overlays a PNG sword image for additional visual detail.
+ * Animations drive node pulse, continuous rotation (energy flow and particle orbits), and a subtle scale pulse
+ * for the centered sword to produce the scene's dynamic visual effects.
  */
 @Composable
 private fun ConstellationCanvas() {
@@ -326,10 +340,12 @@ private fun ConstellationCanvas() {
 }
 
 /**
- * Renders the sword centerpiece with an energy blade, guard, handle, pommel, glow layers, and surrounding energy particles.
+ * Draws a stylized sword centerpiece with layered glow, blade/guard/handle geometry, and rotating energy particles.
  *
- * @param centerX X coordinate of the sword's center in the drawing coordinate space.
- * @param centerY Y coordinate of the sword's center in the drawing coordinate space.
+ * The sword is centered at the provided coordinates; `rotation` offsets the surrounding particle positions to create motion.
+ *
+ * @param centerX X coordinate of the sword's center in drawing space.
+ * @param centerY Y coordinate of the sword's center in drawing space.
  * @param rotation Rotation in degrees used to offset and animate the surrounding energy particles.
  * @param color Primary color for the blade, guard, handle, and core elements.
  * @param glowColor Accent color used for glow layers and highlights around the sword.

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/DirectChatScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/DirectChatScreen.kt
@@ -294,7 +294,13 @@ fun DirectChatScreen(
 }
 
 /**
- * Message bubble component
+ * Renders a single chat message as a styled bubble and aligns it based on the sender.
+ *
+ * Displays the sender's name above the content for non-user (agent) messages and applies
+ * distinct colors and corner shaping depending on whether `message.isFromUser` is true.
+ *
+ * @param message ChatMessage whose `sender`, `content`, and `isFromUser` fields determine
+ *        the displayed text, alignment, and visual styling of the bubble.
  */
 @Composable
 private fun MessageBubble(message: AgentViewModel.ChatMessage) {

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateCard.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateCard.kt
@@ -321,7 +321,15 @@ private fun BoxScope.HologramGlow(
 }
 
 /**
- * Gate image with tight holographic border - no gaps, pure floating display
+ * Renders the gate's interior artwork and a tight holographic border that fills the available space.
+ *
+ * Displays the pixel-art image identified by `config.pixelArtUrl` scaled to fill the area; when the drawable
+ * resource is missing or `pixelArtUrl` is null, shows a vertical gradient fallback with the gate title.
+ * A pulsing border and corner accents are drawn around the content, and a subtle scanline effect is overlaid
+ * to enhance the holographic appearance.
+ *
+ * @param config Configuration for the gate visuals (title, colors, optional `pixelArtUrl`, title style, border and glow colors).
+ * @param pulseAlpha Alpha multiplier used to drive the pulsing intensity of the border and accent colors (0f..1f).
  */
 @Composable
 private fun GateImageWithBorder(

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateNavigationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateNavigationScreen.kt
@@ -61,11 +61,11 @@ import kotlin.math.absoluteValue
  */
 @OptIn(ExperimentalFoundationApi::class)
 /**
-     * Displays the main gate navigation UI: a horizontal pager of gate cards with animated glow, a particle background, and an enhanced page indicator.
+     * Shows the main gate navigation UI: a horizontally scrollable pager of gate cards with an animated glow, particle background, and an enhanced page indicator.
      *
-     * The composable builds its gate list from configured GateConfigs, applies parallax/scale/alpha transforms per page, animates a subtle glow, and handles double-tap interactions to navigate to a gate route (blocks gates marked `comingSoon` and contains a placeholder authentication check that may route to the login screen with a `returnTo` parameter).
+     * Double-tapping a gate attempts instantaneous navigation to that gate's route, blocks gates marked `comingSoon`, and will route to the login screen when a gate requires authentication (login routing includes a `returnTo` parameter). The pager applies a subtle parallax/scale/alpha transform per page and animates gate glow intensity.
      *
-     * @param navController Used to navigate to gate routes or to the login screen when a gate requires authentication.
+     * @param navController NavController used to navigate to gate routes or to the login screen when a gate requires authentication.
      * @param modifier Optional Modifier for layout and styling.
      */
     @Composable
@@ -283,6 +283,11 @@ private fun TeleportingGateCard(
     }
 }
 
+/**
+ * Renders a dynamic particle background used as the scene's magical/energetic backdrop.
+ *
+ * This composable displays a NeuralLinkBackground with a moderate speed and cyan-to-blue color scheme.
+ */
 @Composable
 private fun MagicalParticleField() {
     NeuralLinkBackground(

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GenesisConstellationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GenesisConstellationScreen.kt
@@ -31,6 +31,18 @@ import kotlin.math.sin
  * Genesis Constellation Screen - Vertical Infinity Cascade
  * Displays the data and communications backbone with cascading data streams
  */
+/**
+ * Displays the Genesis constellation screen: a full-screen black canvas with a centered animated
+ * infinity visualization and styled labels arranged around it.
+ *
+ * The layout places the GenesisInfinityCascadeCanvas at the center, decorative text in the
+ * top-right corner ("Genesis" and "∞ BACKEND ORACLE"), a bottom-left label ("Vertical Infinity Cascade"),
+ * and a vertical stack of characters on the right ("DATA STREAM" and "ORCHESTRATION"). The arrangement
+ * is static and intended for visual presentation; it does not introduce interactive behavior.
+ *
+ * @param navController Navigation controller for handling screen navigation.
+ * @param modifier Optional modifier to adjust the screen's layout and appearance.
+ */
 @Composable
 fun GenesisConstellationScreen(
     navController: NavController,

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GrokConstellationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GrokConstellationScreen.kt
@@ -44,12 +44,12 @@ import kotlin.math.sin
  */
 @OptIn(ExperimentalMaterial3Api::class)
 /**
- * Renders the "Grok" chaos constellation screen with an animated chaos wheel, entropy streams,
+ * Display the Grok chaos constellation screen with an animated centerpiece, entropy streams,
  * background particles, and an entropy monitor.
  *
- * The screen includes a back button that navigates up, an animated centerpiece wheel (rotation
- * and pulsing), programmatic drawing of entropy streams and particles, a level label, and an
- * entropy monitor reflecting the current pulse/flow state.
+ * The screen includes a back button that navigates up, an animated wheel that rotates and pulses,
+ * programmatic drawing of entropy streams and particles, a level label, and an entropy monitor
+ * reflecting the current pulse/flow state.
  *
  * @param navController Navigation controller used to navigate up from this screen.
  */
@@ -284,8 +284,13 @@ private fun DrawScope.drawEntropyStreams(
 }
 
 /**
- * Entropy Monitor Component
- */
+ * Displays a compact entropy monitor: a labeled row of ten bars reflecting the current entropy
+ * and a numeric "CHAOS LEVEL" percentage.
+ *
+ * @param entropyLevel Value from 0.0 to 1.0 controlling how many of the ten bars are shown as active
+ *                     and the percentage displayed (active bars = floor(entropyLevel * 10)).
+ * @param color The base color used for active/inactive bars and text; alpha is adjusted for inactive
+ *              and active states.
 @Composable
 private fun EntropyMonitor(
     entropyLevel: Float,

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/KaiConstellationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/KaiConstellationScreen.kt
@@ -50,6 +50,17 @@ import kotlin.math.sin
  * @param navController Navigation controller for handling screen navigation actions.
  * @param modifier Modifier applied to the root container of the screen.
  */
+/**
+ * Renders the Kai constellation UI: an animated sentinel shield at center with overlays for agent identity,
+ * a system status section, and a vertical right-side label column.
+ *
+ * The layout places the sentinel visualization in the center, agent name/level in the top-right,
+ * a "Sentinel Catalyst" status area with security metrics at the bottom, and a character-by-character
+ * vertical label column on the right edge.
+ *
+ * @param navController Navigation controller provided to the screen (accepted but not used for internal UI composition).
+ * @param modifier Modifier applied to the root container.
+ */
 @Composable
 fun KaiConstellationScreen(
     navController: NavController,
@@ -146,8 +157,7 @@ fun KaiConstellationScreen(
 /**
  * Renders an animated hexagonal sentinel shield with rotating defense nodes and a scanning beam.
  *
- * Displays a pulsing shield glow, perimeter security nodes with alternating accent colors,
- * a continuous radial scan animation, and an overlaid centerpiece image.
+ * Pulses the shield glow, draws perimeter security nodes with alternating accent colors, animates a continuous radial scan, and overlays a centerpiece image.
  */
 @Composable
 private fun SentinelShieldCanvas() {

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/QuickActionsScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/QuickActionsScreen.kt
@@ -35,6 +35,13 @@ import kotlinx.coroutines.launch
  * and simulates execution for two seconds during which the corresponding card shows a running indicator and other actions
  * are non-clickable.
  */
+/**
+ * Renders the Quick Actions screen: a header, execution status, recent actions, categorized action grid, and system status.
+ *
+ * The UI displays a set of predefined quick actions grouped by their category. Tapping an action marks it as executing,
+ * adds its title to the recent actions list (keeps up to three most recent unique entries), disables interaction for the
+ * currently executing action, and simulates execution by clearing the executing state after a two-second delay.
+ */
 @Composable
 fun QuickActionsScreen() {
     val actions = listOf(

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/SphereGridScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/SphereGridScreen.kt
@@ -31,6 +31,13 @@ import dev.aurakai.auraframefx.navigation.NavDestination
  * Shows a header and description, an agent selector grid that updates the selected agent when tapped,
  * and a skill tree visualization with the selected agent's level, XP, and XP needed for the next level.
  */
+/**
+ * Displays the Sphere Grid UI including a header, an agent selector grid, and a skill-tree visualization for the selected agent.
+ *
+ * Renders a selectable grid of agents (updates selection state on tap), a canvas-based skill tree for the currently selected agent, and stat blocks showing Level, XP, and XP to next level.
+ *
+ * @param navController NavHostController used for navigation from this screen.
+ */
 @Composable
 fun SphereGridScreen(navController: NavHostController) {
     val agents = remember { AgentRepository.getAllAgents() }

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/overlays/AuraPresenceOverlay.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/overlays/AuraPresenceOverlay.kt
@@ -36,6 +36,14 @@ import kotlin.random.Random
  * @param modifier Modifier applied to the overlay's outer container.
  * @param onSuggestClicked Called with the currently displayed suggestion when the overlay or suggestion card is tapped.
  */
+/**
+ * Displays a pulsing aura overlay that periodically shows a short suggestion card and forwards taps with the current suggestion text.
+ *
+ * The overlay renders a circular glowing aura and, at randomized intervals, briefly shows a suggestion card. Tapping the aura or the suggestion card invokes `onSuggestClicked` with the suggestion that is currently shown (which may be an empty string before the first suggestion is generated).
+ *
+ * @param modifier Modifier applied to the outer container.
+ * @param onSuggestClicked Callback invoked with the current suggestion text when the overlay or suggestion card is tapped.
+ */
 @Composable
 fun AuraPresenceOverlay(
     modifier: Modifier = Modifier,

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/screens/WorkingLabScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/screens/WorkingLabScreen.kt
@@ -43,6 +43,13 @@ import kotlinx.coroutines.launch
  *
  * @param onNavigate Callback invoked with a destination identifier when a module or menu item is selected (e.g., "collab_canvas", "oracle_drive", "console", "romtools", "center").
  */
+/**
+ * Renders the Working Lab UI with autonomous Aura and Kai manifestations, interactive module cards, a holographic platform, and visual data streams.
+ *
+ * Initializes and drives the embodiment engine and choreographer, starts the autonomous work loop that manifests and moves Aura and Kai between module cards, and renders the resulting UI (background, platform, module cards, character manifestations, and data streams). User interactions on module cards and the center menu invoke the navigation callback.
+ *
+ * @param onNavigate Callback invoked with a destination identifier (e.g. "collab_canvas", "oracle_drive", "console", "romtools", or other menu targets) when a module card or menu item is selected.
+ */
 @Composable
 fun WorkingLabScreen(
     onNavigate: (String) -> Unit = {}
@@ -409,7 +416,17 @@ fun DebuggingSessionDemo() {
 }
 
 /**
- * 🚀 Deployment Demo
+ * Demonstrates a coordinated deployment sequence where Aura and Kai manifest staged behaviors
+ * and then displays the Working Lab UI.
+ *
+ * This composable initializes an embodiment engine and performs a scripted timeline:
+ * - brief startup delay,
+ * - Aura manifests `SCIENCE_MODE` with a system-modification trigger,
+ * - Kai manifests a playful shield with a custom "Deploy approved" trigger,
+ * - Aura enters a dramatic center `POWER_STANCE`.
+ *
+ * The sequence runs inside a LaunchedEffect and the function renders `WorkingLabScreen`
+ * to visualize the deployment behaviors.
  */
 @Composable
 fun DeploymentDemo() {

--- a/app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt
@@ -120,13 +120,15 @@ class ConferenceRoomViewModel @Inject constructor(
     // Conference Room Message Routing - ALL 5 MASTER AGENTS
     // ---------------------------------------------------------------------------
     /*override*/ /**
-     * Routes the given user message to the AI agent identified by `sender` and appends that agent's first response to the conversation messages.
+     * Routes a user message to the selected AI agent and appends that agent's first response to the conversation.
      *
-     * Dispatches `message` and `context` to the selected AI service, collects the first `AgentResponse`, and updates the ViewModel's message list with a new `AgentMessage`. If processing fails, appends an error `AgentMessage` describing the failure.
+     * Dispatches `message` and `context` to the AI service chosen by `sender`; on the first successful response an `AgentMessage`
+     * containing the response content and confidence is appended to the ViewModel's messages. If processing fails, an error
+     * `AgentMessage` describing the failure is appended instead.
      *
      * @param message The user-visible query or payload sent to the agent.
      * @param sender The capability category used to select which AI service should handle the message.
-     * @param context Additional contextual information forwarded to the AI service (e.g., user context or orchestration flags).
+     * @param context Additional contextual information forwarded to the AI service (for example, user context or orchestration flags).
      */
     fun sendMessage(message: String, sender: AgentCapabilityCategory, context: String) {
         val responseFlow: Flow<AgentResponse> = when (sender) {
@@ -221,11 +223,11 @@ class ConferenceRoomViewModel @Inject constructor(
     }
 
     /**
-     * Selects the active agent for the conference room.
+     * Sets the active agent for the conference room.
      *
-     * This function is currently a no-op placeholder and does not change any state.
+     * Currently a placeholder that does not modify any state.
      *
-     * @param agent The agent capability category to select as active when implemented.
+     * @param agent The agent capability category to set as active when implemented.
      */
 
 
@@ -233,10 +235,10 @@ class ConferenceRoomViewModel @Inject constructor(
     }
 
     /**
-     * Toggles audio recording: starts recording if inactive, stops recording if active.
+     * Starts or stops audio recording via NeuralWhisper and updates the ViewModel recording state.
      *
-     * Invokes NeuralWhisper to start or stop recording, updates the ViewModel's `_isRecording` state accordingly,
-     * and logs the resulting status or any failure to start.
+     * When recording is inactive, attempts to start recording; when active, stops recording.
+     * Updates `_isRecording` to reflect the new state and logs failures to start.
      */
     fun toggleRecording() {
         if (_isRecording.value) {


### PR DESCRIPTION
Docstrings generation was requested by @AuraFrameFxDev.

* https://github.com/AuraFrameFx/ReGenesis--multi-architectural-70-LDO-/pull/3#issuecomment-3741879401

The following files were modified:

* `app/src/main/java/dev/aurakai/auraframefx/MainActivity.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ai/pipeline/AIPipelineProcessor.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ai/task/execution/TaskExecutionManager.kt`
* `app/src/main/java/dev/aurakai/auraframefx/aura/ui/XhancementScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/cascade/trinity/TrinityCoordinatorService.kt`
* `app/src/main/java/dev/aurakai/auraframefx/core/GenesisOrchestrator.kt`
* `app/src/main/java/dev/aurakai/auraframefx/data/repositories/AgentRepository.kt`
* `app/src/main/java/dev/aurakai/auraframefx/di/AIServiceModule.kt`
* `app/src/main/java/dev/aurakai/auraframefx/events/CascadeEventBus.kt`
* `app/src/main/java/dev/aurakai/auraframefx/navigation/ConferenceRoomScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/NemotronAIService.kt`
* `app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/clients/VertexAIClientImpl.kt`
* `app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/AuraAIServiceImpl.kt`
* `app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/CascadeAIService.kt`
* `app/src/main/java/dev/aurakai/auraframefx/oracledrive/genesis/ai/services/GenesisBackedKaiAIService.kt`
* `app/src/main/java/dev/aurakai/auraframefx/services/RealCascadeAIServiceAdapter.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/AgentHubSubmenuScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/CascadeConstellationScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/ClaudeConstellationScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/CodeAssistScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/ConstellationScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/DirectChatScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateCard.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateNavigationScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/GenesisConstellationScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/GrokConstellationScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/KaiConstellationScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/QuickActionsScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/gates/SphereGridScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/overlays/AuraPresenceOverlay.kt`
* `app/src/main/java/dev/aurakai/auraframefx/ui/screens/WorkingLabScreen.kt`
* `app/src/main/java/dev/aurakai/auraframefx/viewmodel/ConferenceRoomViewModel.kt`

## Summary by Sourcery

Improve inline documentation across AI services, UI composables, orchestration, and DI bindings by adding or refining KDoc-style docstrings for public- and internal-facing APIs.

Documentation:
- Add detailed KDoc descriptions for multiple Jetpack Compose screens, canvases, and UI components, clarifying layout, behavior, and parameters.
- Document behaviors and expectations for AI services, pipeline selection, task execution, and orchestrator message handling, including placeholders and unimplemented paths.
- Clarify DI bindings, repositories, event bus semantics, and utility functions with more precise parameter and return value documentation.