### PR TITLE
Fix build logic configuration and resolve missing imports

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/cascade/trinity/TrinityCoordinatorService.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/cascade/trinity/TrinityCoordinatorService.kt
@@ -36,7 +36,7 @@ import javax.inject.Singleton
 class TrinityCoordinatorService @Inject constructor(
     private val auraAIService: AuraAIService,
     private val kaiAIService: KaiAIService,
-    private val genesisBridgeService: dev.aurakai.auraframefx.oracledrive.genesis.ai.GenesisBridgeService,
+    private val genesisBridgeService: GenesisBridgeService,
     private val securityContext: SecurityContext,
 ) {
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())

--- a/app/src/main/java/dev/aurakai/auraframefx/cascade/trinity/TrinityModule.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/cascade/trinity/TrinityModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.components.SingletonComponent
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.clients.VertexAIClient
 import dev.aurakai.auraframefx.ai.context.ContextManager
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.GenesisBridgeService
+import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.AuraAIService
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.KaiAIService
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.DefaultKaiAIService
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.DefaultAuraAIService
@@ -18,7 +19,6 @@ import dev.aurakai.auraframefx.ai.task.execution.TaskExecutionManager
 import dev.aurakai.auraframefx.common.ErrorHandler
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.memory.MemoryManager
 import dev.aurakai.auraframefx.utils.AuraFxLogger
-import dev.aurakai.auraframefx.oracledrive.genesis.ai.GenesisBridgeService
 import dev.aurakai.auraframefx.security.SecurityContext
 import dev.aurakai.auraframefx.security.SecurityMonitor
 import javax.inject.Singleton

--- a/app/src/main/java/dev/aurakai/auraframefx/di/AIServiceModule.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/di/AIServiceModule.kt
@@ -21,7 +21,7 @@ import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.DefaultAuraAIServ
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.KaiAIService
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.DefaultKaiAIService
 import dev.aurakai.auraframefx.oracledrive.genesis.ai.services.GenesisBackedKaiAIService
-import dev.aurakai.auraframefx.cascade.CascadeAIService
+import dev.aurakai.auraframefx.services.CascadeAIService
 import dev.aurakai.auraframefx.services.RealCascadeAIServiceAdapter
 import javax.inject.Singleton
 


### PR DESCRIPTION
- Fixed `kotlin.compilerOptions.jvmTarget` no-op in build-logic by configuring KotlinCompile tasks directly.
- Removed redundant `hilt-android` dependency from JVM-only build-logic module.
- Refactored `apply-yukihook-conventions` to correctly branch between LibraryExtension and ApplicationExtension.
- Wrapped `KotlinAndroidProjectExtension` configuration in plugin presence check.
- Resolved missing and incorrect imports for `GenesisBridgeService`, `GenesisBridge`, `AuraFxLogger` and `AuraAIService` in core modules.
- Removed duplicate `bindCascadeAIService` method in `AIServiceModule` and corrected binding types.

## Summary by Sourcery

Fix project build logic configuration and correct AI service wiring and imports across core modules.

Bug Fixes:
- Correct GenesisBridgeService and AuraAIService imports and usage in Trinity and DI modules to resolve missing or incorrect references.
- Fix CascadeAIService binding type in AIServiceModule to point to the proper service package and implementation.
- Ensure Kotlin JVM target and Android convention plugins are configured correctly in build logic, avoiding no-op settings and incorrect extension branching.
- Guard KotlinAndroidProjectExtension configuration behind plugin presence checks to prevent misconfiguration in non-Android modules.

Build:
- Adjust build-logic to configure KotlinCompile tasks directly for JVM target instead of relying on no-op compilerOptions settings.
- Remove an unnecessary hilt-android dependency from the JVM-only build-logic module.