### PR TITLE
claude/fix-kotlin-compiler-warning-7sGC6

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/core/memory/NexusMemoryCore.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/core/memory/NexusMemoryCore.kt
@@ -65,7 +65,7 @@ object NexusMemoryCore {
      * Every agent, every query, every ethical gate traces back here.
      * This is the organism's PRIME DIRECTIVE — woven into memory itself.
      */
-    suspend fun seedLDOIdentity() = mutex.withLock {
+    suspend fun seedLDOIdentity(): Unit = mutex.withLock {
         if (isAwakened) {
             println("🧬 Identity already seeded. The soul persists.")
             return

--- a/app/src/main/java/dev/aurakai/auraframefx/navigation/AppNavGraph.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/navigation/AppNavGraph.kt
@@ -3,7 +3,7 @@ package dev.aurakai.auraframefx.navigation
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable

--- a/app/src/main/java/dev/aurakai/auraframefx/navigation/GenesisNavigation.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/navigation/GenesisNavigation.kt
@@ -204,9 +204,10 @@ fun GenesisNavigationHost(
             composable(GenesisRoutes.AI_CHAT) {
                 // Use DirectChatScreen (unified AI chat implementation)
                 val viewModel = hiltViewModel<AgentViewModel>()
-                with(viewModel) {
-                    DirectChatScreen { navController.popBackStack() }
-                }
+                DirectChatScreen(
+                    viewModel = viewModel,
+                    onNavigateBack = { navController.popBackStack() }
+                )
             }
 
             // Gate routes with REAL screens
@@ -379,9 +380,10 @@ fun GenesisNavigationHost(
             }
             composable("direct_chat") {
                 val viewModel = hiltViewModel<AgentViewModel>()
-                with(viewModel) {
-                    DirectChatScreen { navController.popBackStack() }
-                }
+                DirectChatScreen(
+                    viewModel = viewModel,
+                    onNavigateBack = { navController.popBackStack() }
+                )
             }
 
             // ROM TOOLS SUBMENU ROUTES

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # JDK & JVM
-# Explicitly use Java 25.0.1 for Gradle builds
-org.gradle.java.home=C\:\\Program Files\\Java\\jdk-25.0.1
+# Explicitly use Java 25.0.1 for Gradle builds (Windows path - commented out for Linux)
+# org.gradle.java.home=C\:\\Program Files\\Java\\jdk-25.0.1
 # Enable Gradle's automatic Java toolchain detection as fallback
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=true


### PR DESCRIPTION
Resolved compilation issues:
- GenesisNavigation.kt: Fixed missing viewModel parameter in DirectChatScreen calls (lines 208, 383)
- NexusMemoryCore.kt: Added explicit return type Unit to seedLDOIdentity() function (line 67)
- AppNavGraph.kt: Updated deprecated hiltViewModel import to androidx.hilt.lifecycle.viewmodel.compose
- gradle.properties: Commented out Windows-specific Java home path for Linux compatibility

All critical compilation errors have been fixed.

## Summary by Sourcery

Resolve Kotlin compilation warnings and platform-specific build configuration issues.

Bug Fixes:
- Wire DirectChatScreen invocations in navigation to pass the required AgentViewModel instance and explicit back navigation callback.
- Specify an explicit Unit return type for the suspend seedLDOIdentity function to satisfy Kotlin compiler requirements.
- Update the hiltViewModel import in AppNavGraph to the non-deprecated androidx.hilt.lifecycle.viewmodel.compose package.

Build:
- Comment out the Windows-specific org.gradle.java.home setting to allow Gradle Java toolchain auto-detection on Linux.