### PR TITLE
claude/fix-android-fatal-exception-YDzpv

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateNavigationScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/GateNavigationScreen.kt
@@ -106,9 +106,14 @@ fun GateNavigationScreen(
     }
 }
 
+@Composable
 private fun PagerScope.GateCard(
     config: GateConfig,
     modifier: Modifier
 ) {
-    TODO("Not yet implemented")
+    GateCard(
+        config = config,
+        modifier = modifier,
+        onDoubleTap = {} // Double-tap is handled at parent level
+    )
 }


### PR DESCRIPTION
Fixed kotlin.NotImplementedError at GateNavigationScreen.kt:113 by implementing the missing GateCard extension function. The function now properly delegates to the existing GateCard composable with double-tap handling managed at parent level.

This resolves the crash that occurred when rendering gate cards in the HorizontalPager.

## Summary by Sourcery

Bug Fixes:
- Resolve kotlin.NotImplementedError crashes in GateNavigationScreen by delegating the PagerScope.GateCard extension to the existing GateCard composable.