### PR TITLE
Fix Gradle build: Disable AGP built-in Kotlin for KSP compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,8 @@ org.gradle.java.installations.auto-download=true
 org.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8
 
 # AGP 9.0 / Hilt Compatibility Bridge
+# CRITICAL: KSP is not compatible with AGP's built-in Kotlin - must disable
+android.builtInKotlin=false
 android.newDsl=false
 
 # Performance & Modern Defaults


### PR DESCRIPTION
Added android.builtInKotlin=false to gradle.properties to resolve annotation processor conflicts between Dagger Hilt and Room.

Issue: Unable to load class 'dagger.spi.internal.shaded.androidx.room.compiler.processing.javac.JavacBasicAnnotationProcessor'

Root Cause: KSP is not compatible with AGP 9.1.0-alpha05's built-in Kotlin. This was causing classloader conflicts between Hilt and Room annotation processors.

Solution: Disabled built-in Kotlin per official KSP/AGP compatibility guidelines. This is a temporary workaround until full AGP 9.x + KSP compatibility is achieved.

References:
- https://github.com/google/ksp/issues/2615
- https://developer.android.com/build/migrate-to-built-in-kotlin

## Summary by Sourcery

Build:
- Set android.builtInKotlin=false in gradle.properties to avoid classloader conflicts between AGP 9.x built-in Kotlin and KSP.