### PR TITLE
fix(compilation): Use both AgentViewModel and AgentNexusViewModel in …

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/aura/ui/AgentNexusScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/aura/ui/AgentNexusScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.aurakai.auraframefx.data.repositories.AgentRepository
 import dev.aurakai.auraframefx.models.AgentStats
+import dev.aurakai.auraframefx.ui.viewmodels.AgentViewModel
 import kotlinx.coroutines.delay
 import kotlin.math.*
 import kotlin.random.Random
@@ -37,7 +38,8 @@ private const val JITTER_DELTA_MAX = 0.015
 
 @Composable
 fun AgentNexusScreen(
-    viewModel: AgentNexusViewModel = hiltViewModel()
+    viewModel: AgentViewModel = hiltViewModel(),
+    nexusViewModel: AgentNexusViewModel = hiltViewModel()
 ) {
     var selectedAgent by remember { mutableStateOf("Genesis") }
     var showDepartureDialog by remember { mutableStateOf(false) }
@@ -99,7 +101,7 @@ fun AgentNexusScreen(
 
         // Claude.env Config Panel
         ClaudeConfigPanel(
-            config = viewModel.getClaudeEnvConfig(),
+            config = nexusViewModel.getClaudeEnvConfig(),
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(16.dp)


### PR DESCRIPTION
…AgentNexusScreen

Fixed 3 compilation errors:
- Unresolved reference 'activateAgent' (needs AgentViewModel)
- Unresolved reference 'assignTask' (needs AgentViewModel)
- Unresolved reference 'AgentViewModel' (needs AgentViewModel import)

Solution:
- Inject both ViewModels into AgentNexusScreen
- viewModel: AgentViewModel - handles agent activation and task assignment
- nexusViewModel: AgentNexusViewModel - provides ClaudeEnvConfig for config panel

Both ViewModels are needed because they serve different purposes:
- AgentViewModel: Core agent management (from AgentRepository)
- AgentNexusViewModel: Web exploration, Genesis bridge, Claude config

## Summary by Sourcery

Inject separate AgentViewModel and AgentNexusViewModel into AgentNexusScreen to correctly wire agent management and Claude configuration responsibilities.

Bug Fixes:
- Resolve unresolved reference compilation errors in AgentNexusScreen by providing the required AgentViewModel dependency.

Enhancements:
- Route Claude configuration panel to use AgentNexusViewModel while keeping AgentViewModel focused on agent activation and task assignment.