### PR TITLE
feat(navigation): Integrate Iconify and ChromaCore into 3-level gate …

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/navigation/AppNavGraph.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/navigation/AppNavGraph.kt
@@ -31,6 +31,8 @@ import dev.aurakai.auraframefx.ui.customization.ComponentEditor
 import dev.aurakai.auraframefx.ui.customization.ComponentType
 import dev.aurakai.auraframefx.ui.customization.UIComponent
 import dev.aurakai.auraframefx.ui.customization.ZOrderEditor
+import dev.aurakai.auraframefx.iconify.IconPicker
+import dev.aurakai.auraframefx.ui.gates.ChromaCoreColorsScreen
 import dev.aurakai.auraframefx.ui.gates.AgentHubSubmenuScreen
 import dev.aurakai.auraframefx.ui.gates.AgentMonitoringScreen
 import dev.aurakai.auraframefx.ui.gates.AurasLabScreen
@@ -322,6 +324,14 @@ fun AppNavGraph(navController: NavHostController) {
 
         composable(route = NavDestination.ThemeEngine.route) {
             ThemeEngineScreen(onNavigateBack = { navController.popBackStack() })
+        }
+
+        composable(route = NavDestination.IconifyPicker.route) {
+            IconPicker(onNavigateBack = { navController.popBackStack() })
+        }
+
+        composable(route = NavDestination.ChromaCoreColors.route) {
+            ChromaCoreColorsScreen(onNavigateBack = { navController.popBackStack() })
         }
 
         composable(route = NavDestination.StatusBar.route) {

--- a/app/src/main/java/dev/aurakai/auraframefx/navigation/NavDestination.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/navigation/NavDestination.kt
@@ -74,6 +74,12 @@ sealed class NavDestination(val route: String, val title: String, val icon: Imag
     object QuickActions : NavDestination("quick_actions", "Quick Actions", null)
     object SystemOverrides : NavDestination("system_overrides", "System Overrides", null)
 
+    // Iconify Integration
+    object IconifyPicker : NavDestination("iconify_picker", "Iconify", null)
+
+    // ChromaCore - System-wide Color Editor
+    object ChromaCoreColors : NavDestination("chromacore_colors", "ChromaCore Colors", null)
+
     // Help Desk
     object HelpDesk : NavDestination("help_desk", "Help Desk", null)
     object LiveSupport : NavDestination("live_support", "Live Support", null)

--- a/app/src/main/java/dev/aurakai/auraframefx/ui/gates/UIUXGateSubmenuScreen.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/ui/gates/UIUXGateSubmenuScreen.kt
@@ -32,6 +32,20 @@ fun UIUXGateSubmenuScreen(
 ) {
     val menuItems = listOf(
         SubmenuItem(
+            title = "ChromaCore Colors",
+            description = "System-wide color customization for entire device",
+            icon = Icons.Default.Palette,
+            route = NavDestination.ChromaCoreColors.route,
+            color = Color(0xFFFF1493) // Deep Pink
+        ),
+        SubmenuItem(
+            title = "Iconify Picker",
+            description = "250,000+ icons from Iconify API",
+            icon = Icons.Default.Layers,
+            route = NavDestination.IconifyPicker.route,
+            color = Color(0xFF00D1FF) // Neon Blue
+        ),
+        SubmenuItem(
             title = "Theme Engine",
             description = "Customize system colors, fonts, and styles",
             icon = Icons.Default.Palette,


### PR DESCRIPTION
…system

Connected Iconify and ChromaCore ColorBlendr features to the UI/UX Design Gate (Aura Gate → UI/UX Submenu → Iconify/ChromaCore).

Changes:
1. NavDestination.kt:
   - Added IconifyPicker route
   - Added ChromaCoreColors route

2. UIUXGateSubmenuScreen.kt:
   - Added "ChromaCore Colors" as first item (system-wide color customization)
   - Added "Iconify Picker" as second item (250,000+ icons from Iconify API)
   - Reordered menu to prioritize these powerful customization tools

3. AppNavGraph.kt:
   - Added IconPicker composable route
   - Added ChromaCoreColorsScreen composable route
   - Imported both screens

Navigation Path:
Level 1: Aura Gate (wild chaos aesthetic)
  → Level 2: UI/UX Design Gate (blue wireframe cards)
    → Level 3: Iconify Picker / ChromaCore Colors (full screens)

Both features now integrated into the gate navigation instead of separate menus.

## Summary by Sourcery

Integrate Iconify and ChromaCore color customization into the UI/UX gate navigation as first-class destinations.

New Features:
- Add ChromaCore Colors and Iconify Picker entries to the UI/UX Gate submenu for direct access.
- Register navigation destinations and composable screens for Iconify Picker and ChromaCore Colors in the app nav graph.

Enhancements:
- Reorder the UI/UX gate submenu to prioritize global color and icon customization tools.